### PR TITLE
Recent docutils compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,8 +37,8 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v6"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"
@@ -83,8 +83,8 @@ jobs:
     runs-on: "${{ matrix.os }}"
 
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: "actions/setup-python@v4"
+      - uses: "actions/checkout@v6"
+      - uses: "actions/setup-python@v6"
         with:
           python-version: "${{ matrix.python-version }}"
       - name: "Install dependencies"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.7"
-            os: "ubuntu-latest"
-            tox-envs: "py37"
-          - python-version: "3.8"
-            os: "ubuntu-latest"
-            tox-envs: "py38"
           - python-version: "3.9"
             os: "ubuntu-latest"
             tox-envs: "py39"
@@ -27,6 +21,15 @@ jobs:
           - python-version: "3.11"
             os: "ubuntu-latest"
             tox-envs: "py311"
+          - python-version: "3.12"
+            os: "ubuntu-latest"
+            tox-envs: "py312"
+          - python-version: "3.13"
+            os: "ubuntu-latest"
+            tox-envs: "py313"
+          - python-version: "3.14"
+            os: "ubuntu-latest"
+            tox-envs: "py314"
 
     env:
       PY_COLORS: 1
@@ -55,12 +58,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.7"
-            os: "ubuntu-latest"
-            tox-envs: "py37"
-          - python-version: "3.8"
-            os: "ubuntu-latest"
-            tox-envs: "py38"
           - python-version: "3.9"
             os: "ubuntu-latest"
             tox-envs: "py39"
@@ -70,6 +67,15 @@ jobs:
           - python-version: "3.11"
             os: "ubuntu-latest"
             tox-envs: "py311"
+          - python-version: "3.12"
+            os: "ubuntu-latest"
+            tox-envs: "py312"
+          - python-version: "3.13"
+            os: "ubuntu-latest"
+            tox-envs: "py313"
+          - python-version: "3.14"
+            os: "ubuntu-latest"
+            tox-envs: "py314"
 
     env:
       PY_COLORS: 1

--- a/lektor_rst.py
+++ b/lektor_rst.py
@@ -31,11 +31,11 @@ def rst_to_html(text, extra_params, record):
     except:
         writer_name = 'html'
 
-    Writer = docutils.writers.get_writer_class(writer_name)
     pub = docutils.core.Publisher(
         destination_class=docutils.io.StringOutput,
-        writer=Writer())
-    pub.set_components('standalone', 'restructuredtext', 'html')
+        reader="standalone",
+        parser="restructuredtext",
+        writer=writer_name)
     pub.process_programmatic_settings(None, extra_params, None)
     pub.set_source(
         source=StringIO(text),
@@ -71,7 +71,7 @@ class Rst(object):
         self.__cached_for_ctx = None
         self.__html = None
         self.__meta = None
-        
+
     def __bool__(self):
         return bool(self.source)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [devpi:upload]
 formats = sdist.tgz,bdist_wheel

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     install_requires=[
         'Lektor',
         'Pygments',
-        'docutils'],
+        'docutils>=0.21'],
     extras_require={
         'dev': [
             'pyquery',
@@ -20,7 +20,7 @@ setup(
             'pytest-cov',
             'pytest-flake8']},
     py_modules=['lektor_rst'],
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     entry_points={
         'lektor.plugins': [
             'rst = lektor_rst:RstPlugin']})

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='lektor-rst',
     description='Adds reStructuredText support to Lektor.',
-    version='0.3.0',
+    version='0.4.0.dev0',
     author=u'Florian Schulze',
     author_email='florian.schulze@gmx.net',
     url='http://github.com/fschulze/lektor-rst',

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ envlist = py37,py38,py39,py310,py311
 commands =
     py.test --cov lektor_rst {posargs} --cov-report term --cov-report html:{toxinidir}/htmlcov_{envname}
 deps =
-    flake8<5
+    flake8
     pyquery
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = py39,py310,py311,py312,py313,py314
 
 
 [testenv]


### PR DESCRIPTION
This PR addresses a few bit-rot type issues.

1. Address the deprecation of [Publisher.set_components](https://github.com/docutils/docutils/blob/a52ef47c539e580354a1aa6fa937b500d1ee91c1/docutils/docutils/core.py#L115) in `docutils`.  The most straightforward way to deal with this involved pinning `docutils >= 0.21`; that, in turn, requires Python >= 3.9.
2. The pin of `flake8 < 5` in `tox.ini` is incompatible with the current version of `pytest-cov`, resulting in test failures.  To resolve that, this PR removes the pin on `flake 8`.
3. Stop building a _universal wheel_.  Since we no longer support Python 2, there's no reason to do so.

