### PR TITLE
Workaround for pytest vs pytest-flake8 incompatibility

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ commands =
 deps =
     flake8
     pyquery
-    pytest
+    # pytest-flake8 as of 1.3.0 is incompatible with pytest >= 9.1.0.
+    # ref https://github.com/coherent-oss/pytest-flake8/issues/5
+    pytest<9.1
     pytest-cov
     pytest-flake8
 


### PR DESCRIPTION
> [!NOTE]
> PR #15 provides a more complete and forward-looking fix for the current CI test failures (along with more extensive changes).  *Only one of PR #14 or PR #15 should be merged*.  I favor PR #15.

Pytest-flake8 currently uses a deprecated API for pytest plugins. This makes it incompatible with the most recent releases of pytest, and is causing `lektor-rst`s CI tests to [fail](https://github.com/fschulze/lektor-rst/actions/runs/27524565498).

See coherent-oss/pytest-flake8#5 for more details.

Here we pin an older version of pytest to address the issue.

It might perhaps be better to disuse pytest-flake8.  Flake8 (or ruff) could instead be run in a pre-commit hook, or, alternatively, as a separate tox environment.